### PR TITLE
Fix filtered view on reload

### DIFF
--- a/src/helpers/prFilters.ts
+++ b/src/helpers/prFilters.ts
@@ -3,10 +3,10 @@ import { getDisplayName } from './getDisplayName'
 function isBotUser(user: User, filters: Settings_Filters): boolean {
   const displayName = getDisplayName(user)
   const matchesPattern = filters.botPatterns.some(p =>
-    displayName.toLowerCase().includes(p.toLowerCase()),
+    displayName?.toLowerCase().includes(p.toLowerCase()),
   )
   const matchesLogin = filters.botLogins.some(
-    l => user.login.toLowerCase() === l.toLowerCase(),
+    l => user.login?.toLowerCase() === l.toLowerCase(),
   )
   return matchesPattern || matchesLogin
 }

--- a/src/views/DailyHelper/DailyHelper.tsx
+++ b/src/views/DailyHelper/DailyHelper.tsx
@@ -205,7 +205,7 @@ export default function DailyHelper() {
       if (pr.reviewDecision === 'APPROVED') return 0
       if (pr.reviewDecision === 'CHANGES_REQUESTED') return 1
       const humanReviewers = pr.requestedReviewers.filter(
-        r => !filters.botLogins.includes(r.login.toLowerCase()),
+        r => !filters.botLogins.includes(r.login?.toLowerCase()),
       )
       if (!humanReviewers.length) return 3
       return 2 // REVIEW_REQUIRED with human reviewers
@@ -415,12 +415,13 @@ export default function DailyHelper() {
                     key={pr.id}
                     direction="up"
                     in={
-                      getVisibility(pr.labels) &&
-                      (!reviewRequiredFilteredIds ||
-                        reviewRequiredFilteredIds.has(pr.id)) &&
-                      (!isMyPrsFilterActive ||
-                        pr.author.login === viewerLogin) &&
-                      (!isMyWorkFilterActive || isMyWork(pr))
+                      isLoadingAnimationPlaying ||
+                      (getVisibility(pr.labels) &&
+                        (!reviewRequiredFilteredIds ||
+                          reviewRequiredFilteredIds.has(pr.id)) &&
+                        (!isMyPrsFilterActive ||
+                          pr.author.login === viewerLogin) &&
+                        (!isMyWorkFilterActive || isMyWork(pr)))
                     }
                     timeout={400}
                     mountOnEnter


### PR DESCRIPTION
* Fixed a bug where the page was crashing after manual reload when filters were active and another filter was opened
* Fixed a bug where skeleton loading was not shown during reload if filter was active